### PR TITLE
Add: Adds example of Publisher/Subscribe for javascript

### DIFF
--- a/Behavioral/Observer/PublishSubscribePattern/README.md
+++ b/Behavioral/Observer/PublishSubscribePattern/README.md
@@ -1,0 +1,11 @@
+# Note on the differences between the Observer and Publish/Suscribe Pattern
+
+Although the Observer pattern is very useful, one will most often find the Publish/Suscribe varation used in JavaScript.
+
+The Observer pattern requires that the observer object explicitly subscribe to the object firing the event (the Subject). 
+
+![UML of Publish/Subscribe Pattern](https://i.gyazo.com/f87c0918bce7572cba05c0c8b7b992a3.png)
+
+The Publish/Suscribe pattern modifies this requirement by making use of a topic/event channel that sits in between the subscribers and the object firing the event (the publisher). This event based system allows the application to define specfic events that contain values needed by the subscriber. Ideally, this pattern helps to avoid dependencies between the subscriber and publisher.
+
+This pattern differs from the Observer pattern in that it allows any subscriber that implements the appropriate event handler to register and receive event specific notifications from the publisher.

--- a/Behavioral/Observer/PublishSubscribePattern/pubSub.js
+++ b/Behavioral/Observer/PublishSubscribePattern/pubSub.js
@@ -1,0 +1,84 @@
+var PubSub = {};
+
+(function(pubSub) {
+  "use strict";
+
+  var topics = {},
+    lastUid = -1;
+
+  var publish = function(topic, data) {
+    if (!topics.hasOwnProperty(topic)) {
+      return false;
+    }
+
+    var broadcast = function() {
+      var subscribers = topics[topic];
+
+      for (var i = 0, j = subscribers.length; i < j; i++) {
+        try {
+          subscribers[i].func(topic, data);
+        } catch (e) {
+          console.log(e);
+        }
+      }
+    };
+
+    setTimeout(broadcast, 0);
+    return true;
+  };
+
+  pubSub.publish = function(topic, data) {
+    return publish(topic, data, false);
+  };
+
+  pubSub.subscribe = function(topic, func) {
+    var token = (++lastUid).toString();
+
+    // Topic doesn't exist yet
+    if (!topics.hasOwnProperty(topic)) {
+      topics[topic] = [];
+    }
+
+    topics[topic].push({ token: token, func: func });
+
+    // Return unsub token
+    return token;
+  };
+
+  pubSub.unsubscribe = function(token) {
+    for (var prop in topics) {
+      if (topics.hasOwnProperty(prop)) {
+        for (var i = 0, j = topics[prop].length; i < j; i++) {
+          if (topics[prop][i].token === token) {
+            topics[prop].splice(i, 1);
+            return token;
+          }
+        }
+      }
+    }
+
+    return false;
+  };
+})(PubSub);
+
+// Suscriber callback
+var subFunc = function(topics, data) {
+  console.log(topics + ": " + data);
+};
+
+// Add the subscriber callback to the the list of subs to a topic
+// Retain the subscription instance for unsubscribing later
+var testSubscription = PubSub.subscribe("example", subFunc);
+
+PubSub.publish("example", "Testing 1 2 3");
+PubSub.publish("example", ["test", "4", "5", "6"]);
+PubSub.publish("example", [{ test: "Yes" }, { pass: true }]);
+
+// Wrap in setTimeout to be put to the end of the call stack
+setTimeout(function() {
+  PubSub.unsubscribe(testSubscription);
+}, 0);
+
+// Make sure the unsubscribe function worked.
+// (Nothing should be displayed if it is unsubscribed)
+PubSub.publish("example", "not unsubbed");


### PR DESCRIPTION
Adds an example of the Publisher/Subscribe variation of the Observer pattern (which is why it is inside of the Observer folder). I also added an explanation of the differences between the two patterns.