### PR TITLE
Fix readme removing bad URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,7 +37,6 @@ Design patterns may be viewed as a structured approach to computer programming i
   * [Fan Out](Concurrency/Fan%20Out)
   * [Guarded Suspension](Concurrency/Guarded%20Suspension)
   * [Mutext](Concurrency/Mutex)
-  * [Observer Pattern](Concurrency/Observer%20Pattern)
   * [Semaphores](Concurrency/Semaphores)
 * [Creational](Creational)
   * [Abstract Factory](Creational/Abstract%20Factory)


### PR DESCRIPTION
The URL removed was redirecting to [an non-existed page](https://github.com/leonardosibela/design-patterns/blob/master/Concurrency/Observer%20Pattern).
Since the pattern (Observer) was [already defined inside Behavioral](https://github.com/leonardosibela/design-patterns/tree/master/Behavioral/Observer), I just removed the bad URL from[ Concurrency](https://github.com/leonardosibela/design-patterns/tree/master/Concurrency).