### PR TITLE
Implements Dependency Injection for C#

### DIFF
--- a/Miscellaneous/DependencyInjection/C#/DependencyInjection/Concretes/AudioManager.cs
+++ b/Miscellaneous/DependencyInjection/C#/DependencyInjection/Concretes/AudioManager.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DependencyInjection.Interfaces;
+
+namespace DependencyInjection.Concretes
+{
+    class AudioManager : IAudioManager
+    {
+        public void PlaySound()
+        {
+            Console.WriteLine("I will play a sound - Doe Ray Me Far Sew La Tea Doe");
+        }
+    }
+}

--- a/Miscellaneous/DependencyInjection/C#/DependencyInjection/Concretes/GameManager.cs
+++ b/Miscellaneous/DependencyInjection/C#/DependencyInjection/Concretes/GameManager.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DependencyInjection.Interfaces;
+
+namespace DependencyInjection.Concretes
+{
+    class GameManager
+    {
+        private readonly IAudioManager AudioManager;
+        private readonly ISceneManager SceneManager;
+
+        public GameManager(IAudioManager audioManager, ISceneManager sceneManager)
+        {
+            AudioManager = audioManager;
+            SceneManager = sceneManager;
+        }
+
+        public void Tick()
+        {
+            AudioManager.PlaySound();
+            SceneManager.DisplayScene();
+        }
+    }
+}

--- a/Miscellaneous/DependencyInjection/C#/DependencyInjection/Concretes/SceneManager.cs
+++ b/Miscellaneous/DependencyInjection/C#/DependencyInjection/Concretes/SceneManager.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using DependencyInjection.Interfaces;
+
+namespace DependencyInjection.Concretes
+{
+    class SceneManager : ISceneManager
+    {
+        List<String> Scenes = new List<String>();
+
+        public void DisplayScene()
+        {
+            Console.WriteLine("I will display the Scene");
+        }
+
+        public void ListScenes()
+        {
+            Scenes.ForEach(x => Console.WriteLine(x));
+        }
+    }
+}

--- a/Miscellaneous/DependencyInjection/C#/DependencyInjection/Interfaces/IAudioManager.cs
+++ b/Miscellaneous/DependencyInjection/C#/DependencyInjection/Interfaces/IAudioManager.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DependencyInjection.Interfaces
+{
+    interface IAudioManager
+    {
+        void PlaySound();
+    }
+}

--- a/Miscellaneous/DependencyInjection/C#/DependencyInjection/Interfaces/ISceneManager.cs
+++ b/Miscellaneous/DependencyInjection/C#/DependencyInjection/Interfaces/ISceneManager.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DependencyInjection.Interfaces
+{
+    interface ISceneManager
+    {
+        void DisplayScene();
+        void ListScenes();
+    }
+}

--- a/Miscellaneous/DependencyInjection/C#/DependencyInjection/Program.cs
+++ b/Miscellaneous/DependencyInjection/C#/DependencyInjection/Program.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using DependencyInjection.Concretes;
+
+namespace DependencyInjection
+{
+    // Overview: Depency Injection, a broader technique of inversion of control, is one in which an object receives the dependencies - in the form of objects - that it depends on. 
+
+    // Scenario: 
+    //    Suppose that we have a game manager that is responsible for managing displaying scenes via a Scene Manager and playing audio via an Audio Manager. Now, we don't want to
+    // instantiate the instances of these objects directly in the game manager itself, but rather instantiate it in what we can call the composition root (in this case, the main program
+    // class). This is because we should be able to swap out the implementation of the Scene Manage or the Audio Manager without the Game Manager worrying about how they are implemented.
+    // So, what we can instead do is create interfaces, ISceneManager and IAudioManager and have the SceneManager and AudioManager implement each of the interfaces respectively.
+    // We then update the GameManager class to take instances of this interface in the constructor instead of instantiating instances of the SceneManager and AudioManager directly in the
+    // GameManager itself. We then instantiate our desired implementations of the interface in the composition root, pass in the instances in the constructor of the GameManager when we construct
+    // the object, and voila, we have dependency injection.
+
+    // So, essentially, what it boils down to is that dependency injection reduces coupling between classes and their dependencies.
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            AudioManager audioManager = new AudioManager();
+            SceneManager sceneManager = new SceneManager();
+
+            GameManager gameManager = new GameManager(audioManager, sceneManager);
+
+            gameManager.Tick();
+        }
+    }
+}


### PR DESCRIPTION
This is a simple dependency injection example for C#  using the notion of a Game Manager that has a Scene Manager and Audio Manager dependency. We create Interfaces for each of these dependencies and pass in instances of this interface in the constructor of the Game Manager class, injecting the dependant objects when we construct the instance of the Game Manager class and thus implementing dependency injection.