### PR TITLE
Add csharp thread pool example

### DIFF
--- a/Concurrency/ThreadPool/csharp/ThreadPoolExample.cs
+++ b/Concurrency/ThreadPool/csharp/ThreadPoolExample.cs
@@ -1,0 +1,39 @@
+namespace ThreadTest;
+
+public static class ThreadPoolExample
+{
+  public static void DoMultiThreadedWork(int numberOfJobs = 400)
+  {
+    for (int i = 0; i < numberOfJobs; i++)
+    {
+      // Add a work item to the ith spot in the queue.
+      ThreadPool.QueueUserWorkItem(WorkItem, i);
+      
+      // Set the min number of thread that should be working on this queue.
+      ThreadPool.SetMinThreads(6, 4);
+
+      // Set the max number of threads assigned to this queue.
+      // We typically want one thread per core on the cpu.
+      ThreadPool.SetMaxThreads(10, 4);
+
+      while (ThreadPool.PendingWorkItemCount != 0)
+      {
+        // Show console output of the current thread count, completed work item count,
+        // and pending work item count.
+        Console.WriteLine($"Threads={ThreadPool.ThreadCount,2}");
+        Console.WriteLine($"Completed={ThreadPool.CompletedWorkItemCount,-3}");
+        Console.WriteLine($"Pending={ThreadPool.PendingWorkItemCount,-3}");
+        Console.WriteLine();
+        Thread.Sleep(200);
+      }
+    }
+  }
+
+  static void WorkItem(object o)
+  {
+    // This represents a work item that a thread will pick up.
+    // We are calling a random sleep time to similate the job being performed.
+    // Each simulated job will take between .2 and 1.1 seconds to complete.
+    Thread.Sleep(new Random().Next(200, 1100));
+  }
+}


### PR DESCRIPTION
### Proposed changes:
Adding an example of thread pooling using c#. 

### Tests:
I ran the example locally using .Net 6, to ensure it is working. 

### To run this file: 
1. Add a new console application using .Net 6. You can do this easily with Rider or Visual Studio
2.  Paste the following over the contents of the Program.cs file:
```cs
using ThreadTest;

Console.WriteLine("Hello, starting thread pool example!");
ThreadPoolExample.DoMultiThreadedWork();
Console.WriteLine("--> Finished!");
```